### PR TITLE
Extra functionality added + some bug fix

### DIFF
--- a/POM/CustomMatcher/customMatcher.ts
+++ b/POM/CustomMatcher/customMatcher.ts
@@ -1,0 +1,124 @@
+import { Locator } from "@playwright/test";
+
+export const customMatchers = {
+    async isImgLoaded(this: any, received: Locator) {
+
+        if (!received || typeof received.evaluate !== 'function') {
+            return {
+                message: () => `Expected a Playwright Locator but received ${typeof received}`,
+                pass: false,
+            };
+        }
+
+        try {
+            // Wait for the image to be visible and ready
+            await received.waitFor({ state: 'visible', timeout: 5000 });
+
+            const isLoaded = await received.evaluate(
+                (img: HTMLImageElement) => img.complete && img.naturalWidth > 0
+            );
+
+            if (isLoaded) {
+                return {
+                    message: () => `Expected image not to be loaded, but it is loaded.`,
+                    pass: true,
+                };
+            } else {
+                return {
+                    message: () => `Expected image to be loaded, but it is not.`,
+                    pass: false,
+                };
+            }
+        } catch (err) {
+            return {
+                message: () => `Expected image to be loaded, but it didn't load in time.`,
+                pass: false,
+            };
+        }
+    },
+
+    async cssAfterHas(this: any, received: Locator, property: string, value: string) {
+        if (!received || typeof received.evaluate !== 'function') {
+            return {
+                message: () => `Expected a Playwright Locator but received ${typeof received}`,
+                pass: false,
+            };
+        }
+    
+        try {
+            // Wait for the element to be visible
+            await received.waitFor({ state: 'visible', timeout: 5000 });
+    
+            // Get the computed CSS property value for the ::after pseudo-element
+            const cssValue = await received.evaluate(
+                (el: HTMLElement, property: string) => {
+                    // Target the ::after pseudo-element using getComputedStyle
+                    const computedStyle = window.getComputedStyle(el, '::after');
+                    return computedStyle.getPropertyValue(property).trim();
+                },
+                property
+            );
+    
+            // Check if the CSS value matches the expected value
+            if (cssValue === value) {
+                return {
+                    message: () => `Expected element not to have CSS property "${property}" with value "${value}", but it does.`,
+                    pass: true,  // Pass: The property value matches the expected value
+                };
+            } else {
+                return {
+                    message: () => `Expected element to have CSS property "${property}" with value "${value}", but found "${cssValue}".`,
+                    pass: false,  // Fail: The property value doesn't match the expected value
+                };
+            }
+        } catch (err) {
+            return {
+                message: () => `Failed to check CSS property "${property}" due to an error: ${err instanceof Error ? err.message : 'unknown error'}`,
+                pass: false,  // Fail: Something went wrong (e.g., timeout or invalid selector)
+            };
+        }
+    },
+    
+    async cssBeforeHas(this: any, received: Locator, property: string, value: string) {
+        if (!received || typeof received.evaluate !== 'function') {
+            return {
+                message: () => `Expected a Playwright Locator but received ${typeof received}`,
+                pass: false,
+            };
+        }
+    
+        try {
+            // Wait for the element to be visible
+            await received.waitFor({ state: 'visible', timeout: 5000 });
+    
+            // Get the computed CSS property value for the ::before pseudo-element
+            const cssValue = await received.evaluate(
+                (el: HTMLElement, property: string) => {
+                    // Target the ::before pseudo-element using getComputedStyle
+                    const computedStyle = window.getComputedStyle(el, '::before');
+                    return computedStyle.getPropertyValue(property).trim();
+                },
+                property
+            );
+    
+            // Check if the CSS value matches the expected value
+            if (cssValue === value) {
+                return {
+                    message: () => `Expected element not to have CSS property "${property}" with value "${value}", but it does.`,
+                    pass: true,  // Pass: The property value matches the expected value
+                };
+            } else {
+                return {
+                    message: () => `Expected element to have CSS property "${property}" with value "${value}", but found "${cssValue}".`,
+                    pass: false,  // Fail: The property value doesn't match the expected value
+                };
+            }
+        } catch (err) {
+            return {
+                message: () => `Failed to check CSS property "${property}" due to an error: ${err.message}`,
+                pass: false,  // Fail: Something went wrong (e.g., timeout or invalid selector)
+            };
+        }
+    }
+    
+};

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,11 @@
+import { Locator } from '@playwright/test';
+
+declare global {
+    namespace PlaywrightTest {
+        interface Matchers<R> {
+            isImgLoaded(): R;
+            cssAfterHas(property: string, value: string): R;
+            cssBeforeHas(property: string, value: string): R;
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {},
   "dependencies": {
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "typescript": "^5.7.2"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,11 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices, expect } from '@playwright/test';
 import { baseConfig } from './config/config';
 import dotenv from 'dotenv';
+import { customMatchers } from './POM/CustomMatcher/customMatcher';
 
 
 dotenv.config();
-
+expect.extend(customMatchers);
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -1,13 +1,18 @@
 import { test, expect, type Page } from "@playwright/test";
-import { DBEngine, ServerManager, ServerProvider, ServerType } from "../POM/Classes/ServerManager.class";
-import { Server } from "../POM/Classes/Server/Server.class";
-import exp from "constants";
+
+// import "../POM/CustomMatchers/isImgLoaded";
+
+// expect.extend({ isImgLoaded });
+
+// import { DBEngine, ServerManager, ServerProvider, ServerType } from "../POM/Classes/ServerManager.class";
+// import { Server } from "../POM/Classes/Server/Server.class";
+
 let page: Page
-let server: Server;
-let vultr_server: Server;
-let hetzner_server: Server;
-let gcp_server: Server;
-let aws_server: Server;
+// let server: Server;
+// let vultr_server: Server;
+// let hetzner_server: Server;
+// let gcp_server: Server;
+// let aws_server: Server;
 
 test.describe.configure({ mode: 'serial' });
 
@@ -33,7 +38,7 @@ test.beforeAll(async ({ browser }) => {
     // vultr_server = await Server(page, 'id');
     // hetzner_server = await Server(page, 'id');
     // gcp_server = await Server(page, 'id');
-    await server.loadData();
+    // await server.loadData();
     
 });
 
@@ -42,6 +47,21 @@ test.afterAll(async () => {
     await page.close();
 });
 
+test("Before Content Check", async() => {
+    await page.goto('https://db262a91-2ad1-4c2b-8295-bfe072de448c-00-2odnt9nb2f2cj.pike.replit.dev/');
+    await expect(page.locator('#box1')).cssBeforeHas('content', '"Before Hover"');
+})
+
+// test("Image Load Test Image", async () => {
+
+//     await page.goto('https://db262a91-2ad1-4c2b-8295-bfe072de448c-00-2odnt9nb2f2cj.pike.replit.dev/');
+//     await expect(page.locator('#imageOne')).isImgLoaded();
+// })
+
+// test("Image is not load test", async() => {
+//     await page.goto('https://db262a91-2ad1-4c2b-8295-bfe072de448c-00-2odnt9nb2f2cj.pike.replit.dev/');
+//     await expect(page.locator('#imageTwo')).not.isImgLoaded();
+// })
 // test('Create Server Test', async() => {
 
 //     const success = await server.provisionServer();
@@ -50,19 +70,19 @@ test.afterAll(async () => {
     
 // });
 
-test('Create Site Test hello-site', async() => {
-    const i = await server.createSite('hello-site');
-    const site = server.sites[i - 1]; 
-    expect(i).not.toBe(-1);
-    expect(site.siteId).not.toBe('');
-})
+// test('Create Site Test hello-site', async() => {
+//     const i = await server.createSite('hello-site');
+//     const site = server.sites[i - 1]; 
+//     expect(i).not.toBe(-1);
+//     expect(site.siteId).not.toBe('');
+// })
 
-test('Create site demo-site', async() => {
-    const i = await server.createSite("demo-site",{fullObjectCaching:true,objectCaching:true,phpVersion:"8.2",wpVersion:"6.4"});
-    const site = server.sites[i - 1]; 
-    expect(i).not.toBe(-1);
-    expect(site.siteId).not.toBe('');
-})
+// test('Create site demo-site', async() => {
+//     const i = await server.createSite("demo-site",{fullObjectCaching:true,objectCaching:true,phpVersion:"8.2",wpVersion:"6.4"});
+//     const site = server.sites[i - 1]; 
+//     expect(i).not.toBe(-1);
+//     expect(site.siteId).not.toBe('');
+// })
 
 
 // test('Server Delete Test', async()=>{

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,112 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "rewriteRelativeImportExtensions": true,          /* Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  },
+  "include": ["**/*.ts"],
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,6 +21,11 @@ dotenv@^16.4.5:
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz"
   integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 playwright-core@1.46.1:
   version "1.46.1"
   resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.1.tgz"
@@ -34,6 +39,11 @@ playwright@1.46.1:
     playwright-core "1.46.1"
   optionalDependencies:
     fsevents "2.3.2"
+
+typescript@^5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
+  integrity sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==
 
 undici-types@~6.19.2:
   version "6.19.8"


### PR DESCRIPTION
### Comparison Summary
The comparison between the `dev` and `typescriptInclude` branches includes the following changes:
- Addition of new TypeScript files for custom matchers.
- Updates to `global.d.ts` and `tsconfig.json`.
- Changes to `package.json`.
- Modifications to several test files and Playwright configuration.

### Recent Commits
- [Extra functionality added](https://github.com/reduanmasud/xCloud-automation/commit/e5b755198df50b25d901861ed2d5d5593ad9fd3a)
- [Typo](https://github.com/reduanmasud/xCloud-automation/commit/bd97683f722ef39124bc8b0fac4a4e4823a89f93)
- [Small fix](https://github.com/reduanmasud/xCloud-automation/commit/7157b798ad3e9324e5e72dbbd0b62c56d27025aa)

**Description:**
This pull request aims to merge the changes from the `typescriptInclude` branch into the `dev` branch. Key updates include:
- Integration of custom matchers for Playwright.
- Updates to TypeScript configuration and dependencies.
- Improvements and fixes in test files and configurations.

### Added Methods
1. **isImgLoaded**
   Checks if an image is loaded.

   **Example:**
   ```typescript
   await expect(page.locator('#imageOne')).isImgLoaded();
   ```

2. **cssAfterHas**
   Checks the CSS property value of the `::after` pseudo-element.

   **Example:**
   ```typescript
   await expect(page.locator('#box1')).cssAfterHas('content', '"After Hover"');
   ```

3. **cssBeforeHas**
   Checks the CSS property value of the `::before` pseudo-element.

   **Example:**
   ```typescript
   await expect(page.locator('#box1')).cssBeforeHas('content', '"Before Hover"');
   ```
